### PR TITLE
Enable annotation creation with JSON download

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,13 +22,16 @@
     <img id="image" src="seo016629-000-007.jpg" alt="Portrait">
     <canvas id="overlay"></canvas>
 </div>
+<button id="downloadBtn">Download JSON</button>
 <script>
 const image = document.getElementById('image');
 const canvas = document.getElementById('overlay');
 const ctx = canvas.getContext('2d');
 const authorSelect = document.getElementById('authorSelect');
 const objectSelect = document.getElementById('objectSelect');
+const downloadBtn = document.getElementById('downloadBtn');
 let annotations = [];
+let currentPolygon = [];
 
 fetch('annotations.json')
     .then(res => res.json())
@@ -71,6 +74,48 @@ function draw() {
 authorSelect.addEventListener('change', draw);
 objectSelect.addEventListener('change', draw);
 image.onload = draw;
+
+canvas.addEventListener('click', e => {
+    const rect = canvas.getBoundingClientRect();
+    const x = (e.clientX - rect.left) / canvas.width;
+    const y = (e.clientY - rect.top) / canvas.height;
+    currentPolygon.push([x, y]);
+    draw();
+    drawCurrent();
+});
+
+canvas.addEventListener('dblclick', () => {
+    if (currentPolygon.length > 2) {
+        const author = prompt('Author?') || 'unknown';
+        const object = prompt('Object?') || 'object';
+        annotations.push({ author, object, points: currentPolygon });
+        populateFilters();
+    }
+    currentPolygon = [];
+    draw();
+});
+
+function drawCurrent() {
+    if (currentPolygon.length === 0) return;
+    ctx.beginPath();
+    currentPolygon.forEach((p, i) => {
+        const x = p[0] * canvas.width;
+        const y = p[1] * canvas.height;
+        if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
+    });
+    ctx.strokeStyle = 'blue';
+    ctx.lineWidth = 1;
+    ctx.stroke();
+}
+
+downloadBtn.addEventListener('click', () => {
+    const dataStr = 'data:text/json;charset=utf-8,' +
+        encodeURIComponent(JSON.stringify(annotations, null, 2));
+    const a = document.createElement('a');
+    a.href = dataStr;
+    a.download = 'annotations.json';
+    a.click();
+});
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- keep seo016629-000-007.jpg as the loaded image
- allow users to create polygon annotations by clicking on the image
- add `Download JSON` button to save the annotations

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_683e6e64371083298fa3e31742df5a7d