### PR TITLE
Disable annotation modal

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # kport-anno
 
-This project is a simple Korean portrait annotation viewer. It loads annotations from `annotations.json` and displays polygons over an image with options to filter by author or object label.
+This project is a simple Korean portrait annotation viewer. It loads annotations from
+`annotations.json` and displays polygons over an image with options to filter by author or
+object label.
+
+The original interface included a modal form for creating new annotations when the canvas was
+double‑clicked. This modal has been disabled so the viewer now works in a read‑only fashion.
 
 The UI and structure mirror the `jport-anno` project.

--- a/script.js
+++ b/script.js
@@ -132,10 +132,10 @@ canvas.addEventListener('click', e => {
 });
 
 canvas.addEventListener('dblclick', e => {
-  if (currentPolygon.length > 2) {
-    form.reset();
-    modal.classList.remove('hidden');
-  }
+  // Double-click now simply clears the current polygon without
+  // showing the annotation modal.
+  currentPolygon = [];
+  draw();
   e.preventDefault();
 });
 


### PR DESCRIPTION
## Summary
- disable double-click modal to keep the viewer read-only
- document that the modal form was removed

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_683e7c6b36b88329bd449848c4b0effd