### PR TITLE
Fix annotation modal behavior

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,6 +27,7 @@
     </div>
     <aside id="infoPanel"></aside>
 </div>
+<button id="addBtn">Add Annotation</button>
 <button id="downloadBtn">Download JSON</button>
 <div id="modal" class="hidden">
     <div id="modalContent">

--- a/script.js
+++ b/script.js
@@ -7,6 +7,7 @@ const form = document.getElementById('annotationForm');
 const cancelBtn = document.getElementById('cancelBtn');
 const tooltip = document.getElementById('tooltip');
 const downloadBtn = document.getElementById('downloadBtn');
+const addBtn = document.getElementById('addBtn');
 const authorFilter = document.getElementById('authorFilter');
 const objectFilter = document.getElementById('objectFilter');
 
@@ -31,6 +32,9 @@ image.onload = () => {
 
 authorFilter.addEventListener('change', applyFilters);
 objectFilter.addEventListener('change', applyFilters);
+addBtn.addEventListener('click', () => {
+  modal.classList.remove('hidden');
+});
 
 function updateFilterOptions() {
   const authors = [...new Set(annotations.map(a => a.author))];
@@ -159,6 +163,14 @@ cancelBtn.addEventListener('click', () => {
   currentPolygon = [];
   modal.classList.add('hidden');
   draw();
+});
+
+modal.addEventListener('click', e => {
+  if (e.target === modal) {
+    currentPolygon = [];
+    modal.classList.add('hidden');
+    draw();
+  }
 });
 
 downloadBtn.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- add **Add Annotation** button
- allow opening the modal only on button click
- hide modal when user clicks outside of it

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_b_683e7e79a1508329bd4517294b27f664