### PR TITLE
Fix overlay alignment with responsive image

### DIFF
--- a/script.js
+++ b/script.js
@@ -24,11 +24,21 @@ fetch('annotations.json')
     applyFilters();
   });
 
+function setCanvasSize() {
+  canvas.width = image.clientWidth;
+  canvas.height = image.clientHeight;
+}
+
 image.onload = () => {
-  canvas.width = image.width;
-  canvas.height = image.height;
+  setCanvasSize();
   applyFilters();
 };
+
+window.addEventListener('resize', () => {
+  setCanvasSize();
+  rebuildPaths();
+  draw();
+});
 
 authorFilter.addEventListener('change', applyFilters);
 objectFilter.addEventListener('change', applyFilters);

--- a/style.css
+++ b/style.css
@@ -21,8 +21,6 @@ body {
     position: absolute;
     top: 0;
     left: 0;
-    width: 100%;
-    height: 100%;
 }
 
 #infoPanel {


### PR DESCRIPTION
## Summary
- resize canvas to match displayed image size
- remove CSS stretching from overlay canvas

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_b_683e846dbe388329ab19c4c0c6ecb9e9