### PR TITLE
Add annotation CRUD features with local storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # kport-anno
 
-This project is a simple Korean portrait annotation viewer. It loads annotations from
-`annotations.json` and displays polygons over an image with options to filter by author or
-object label.
+This project is a simple Korean portrait annotation viewer and editor. It loads annotations from
+`annotations.json` and displays polygons over an image with options to filter by author or object
+label.
 
-The original interface included a modal form for creating new annotations when the canvas was
-double‑clicked. This modal has been disabled so the viewer now works in a read‑only fashion.
+Annotations can be created, edited and removed directly in the browser. All changes are stored in
+`localStorage` so refreshing the page keeps your work. Use the **Download JSON** button to retrieve
+a copy of the current data.
 
 The UI and structure mirror the `jport-anno` project.

--- a/index.html
+++ b/index.html
@@ -19,6 +19,7 @@
         </select>
     </label>
     <button id="addBtn" disabled>Add Annotation</button>
+    <button id="editBtn" disabled>Edit Selected</button>
     <button id="deleteBtn" disabled>Delete Selected</button>
     <button id="downloadBtn">Download JSON</button>
 </div>
@@ -32,7 +33,7 @@
 </div>
 <div id="modal" class="hidden">
     <div id="modalContent">
-        <h2>New Annotation</h2>
+        <h2 id="modalTitle">New Annotation</h2>
         <form id="annotationForm">
             <label>Author
                 <input type="text" name="author" required>

--- a/script.js
+++ b/script.js
@@ -5,9 +5,11 @@ const infoPanel = document.getElementById('infoPanel');
 const modal = document.getElementById('modal');
 const form = document.getElementById('annotationForm');
 const cancelBtn = document.getElementById('cancelBtn');
+const modalTitle = document.getElementById('modalTitle');
 const tooltip = document.getElementById('tooltip');
 const downloadBtn = document.getElementById('downloadBtn');
 const addBtn = document.getElementById('addBtn');
+const editBtn = document.getElementById('editBtn');
 const deleteBtn = document.getElementById('deleteBtn');
 const authorFilter = document.getElementById('authorFilter');
 const objectFilter = document.getElementById('objectFilter');
@@ -19,17 +21,35 @@ let paths = [];
 let pendingPaths = [];
 let currentPolygon = [];
 let selected = null;
+let editingIndex = null;
 let isDragging = false;
 let dragStart = null;
 
-fetch('annotations.json')
-  .then(r => r.json())
-  .then(data => {
-    annotations = data;
-    updateFilterOptions();
-    applyFilters();
-    updateButtonStates();
-  });
+function saveAnnotations() {
+  localStorage.setItem('annotations', JSON.stringify(annotations));
+}
+
+function loadAnnotations() {
+  const data = localStorage.getItem('annotations');
+  return data ? JSON.parse(data) : null;
+}
+
+const stored = loadAnnotations();
+if (stored) {
+  annotations = stored;
+  updateFilterOptions();
+  applyFilters();
+  updateButtonStates();
+} else {
+  fetch('annotations.json')
+    .then(r => r.json())
+    .then(data => {
+      annotations = data;
+      updateFilterOptions();
+      applyFilters();
+      updateButtonStates();
+    });
+}
 
 function setCanvasSize() {
   canvas.width = image.clientWidth;
@@ -51,8 +71,21 @@ authorFilter.addEventListener('change', applyFilters);
 objectFilter.addEventListener('change', applyFilters);
 addBtn.addEventListener('click', () => {
   if (selected && selected.type === 'pending') {
+    modalTitle.textContent = 'New Annotation';
     modal.classList.remove('hidden');
   }
+});
+editBtn.addEventListener('click', () => {
+  if (!(selected && selected.type === 'annotation')) return;
+  const ann = displayedAnnotations[selected.index];
+  editingIndex = annotations.indexOf(ann);
+  if (editingIndex === -1) return;
+  form.author.value = ann.author;
+  form.object.value = ann.object;
+  form.description.value = ann.description || '';
+  form.tags.value = (ann.tags || []).join(', ');
+  modalTitle.textContent = 'Edit Annotation';
+  modal.classList.remove('hidden');
 });
 deleteBtn.addEventListener('click', () => {
   if (!selected) return;
@@ -64,6 +97,7 @@ deleteBtn.addEventListener('click', () => {
     if (idx !== -1) annotations.splice(idx, 1);
   }
   selected = null;
+  saveAnnotations();
   updateFilterOptions();
   applyFilters();
   updateButtonStates();
@@ -208,6 +242,9 @@ canvas.addEventListener('mousedown', e => {
 });
 
 canvas.addEventListener('mouseup', () => {
+  if (isDragging && selected && selected.type === 'annotation') {
+    saveAnnotations();
+  }
   isDragging = false;
 });
 
@@ -259,18 +296,30 @@ canvas.addEventListener('dblclick', e => {
 
 form.addEventListener('submit', e => {
   e.preventDefault();
-  if (!(selected && selected.type === 'pending')) return;
-  const ann = {
-    author: form.author.value,
-    object: form.object.value,
-    description: form.description.value,
-    tags: form.tags.value.split(',').map(t => t.trim()).filter(t => t),
-    points: pendingPolygons[selected.index]
-  };
-  annotations.push(ann);
-  pendingPolygons.splice(selected.index, 1);
-  selected = null;
+  if (editingIndex !== null) {
+    const ann = annotations[editingIndex];
+    ann.author = form.author.value;
+    ann.object = form.object.value;
+    ann.description = form.description.value;
+    ann.tags = form.tags.value.split(',').map(t => t.trim()).filter(t => t);
+    editingIndex = null;
+    selected = null;
+  } else if (selected && selected.type === 'pending') {
+    const ann = {
+      author: form.author.value,
+      object: form.object.value,
+      description: form.description.value,
+      tags: form.tags.value.split(',').map(t => t.trim()).filter(t => t),
+      points: pendingPolygons[selected.index]
+    };
+    annotations.push(ann);
+    pendingPolygons.splice(selected.index, 1);
+    selected = null;
+  } else {
+    return;
+  }
   modal.classList.add('hidden');
+  saveAnnotations();
   updateFilterOptions();
   applyFilters();
   updateButtonStates();
@@ -278,11 +327,17 @@ form.addEventListener('submit', e => {
 
 cancelBtn.addEventListener('click', () => {
   modal.classList.add('hidden');
+  editingIndex = null;
+  modalTitle.textContent = 'New Annotation';
+  updateButtonStates();
 });
 
 modal.addEventListener('click', e => {
   if (e.target === modal) {
     modal.classList.add('hidden');
+    editingIndex = null;
+    modalTitle.textContent = 'New Annotation';
+    updateButtonStates();
   }
 });
 
@@ -307,5 +362,6 @@ function showInfo(index) {
 
 function updateButtonStates() {
   addBtn.disabled = !(selected && selected.type === 'pending');
+  editBtn.disabled = !(selected && selected.type === 'annotation');
   deleteBtn.disabled = !selected;
 }


### PR DESCRIPTION
## Summary
- allow creating, editing and deleting annotations
- persist changes in `localStorage`
- enable editing via new **Edit Selected** button and modal title switch
- update README to describe editing

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_b_683e89df06248329a5048bd041d3f507