### PR TITLE
Add Vite Codespaces setup with Supabase

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,10 @@
+{
+  "name": "kport-anno",
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "18"
+    }
+  },
+  "forwardPorts": [5173],
+  "postCreateCommand": "npm install"
+}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,25 @@
+name: Deploy
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run build
+      - uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./dist
+          publish_branch: gh-pages

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.env
+/dist

--- a/README.md
+++ b/README.md
@@ -1,11 +1,39 @@
 # kport-anno
 
-This project is a simple Korean portrait annotation viewer and editor. It loads annotations from
-`annotations.json` and displays polygons over an image with options to filter by author or object
-label.
+This project is a Vite-based Korean portrait annotation viewer and editor with Supabase integration.
 
-Annotations can be created, edited and removed directly in the browser. All changes are stored in
-`localStorage` so refreshing the page keeps your work. Use the **Download JSON** button to retrieve
-a copy of the current data.
+## GitHub Codespaces
 
-The UI and structure mirror the `jport-anno` project.
+1. Open this repository in **GitHub Codespaces**. The dev container installs Node.js 18 and automatically runs `npm install`.
+2. Create a `.env` file with your Supabase credentials:
+   ```
+   VITE_SUPABASE_URL=https://your-project.supabase.co
+   VITE_SUPABASE_KEY=your-anon-key
+   ```
+
+## Development
+
+Run the dev server:
+
+```bash
+npm run dev
+```
+
+The app will be available on port **5173**.
+
+## Features
+
+- Canvas based polygon annotation interface
+- Create, edit, and delete annotations
+- Filter annotations by author and object
+- Download annotations as JSON
+- Data loaded from and saved to the Supabase `annotations` table
+
+## Build & Preview
+
+```bash
+npm run build
+npm run preview
+```
+
+The project is configured to deploy the built `dist/` folder to the `gh-pages` branch using GitHub Actions.

--- a/index.html
+++ b/index.html
@@ -60,7 +60,6 @@
         </form>
     </div>
 </div>
-<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
-<script src="script.js"></script>
+<script type="module" src="/script.js"></script>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "kport-anno",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@supabase/supabase-js": "^2.0.0",
+    "vite": "^4.0.0"
+  }
+}

--- a/script.js
+++ b/script.js
@@ -1,3 +1,5 @@
+import { createClient } from '@supabase/supabase-js';
+
 const image = document.getElementById('image');
 const canvas = document.getElementById('overlay');
 const ctx = canvas.getContext('2d');
@@ -20,13 +22,9 @@ const authorFilter = document.getElementById('authorFilter');
 const objectFilter = document.getElementById('objectFilter');
 
 // Supabase client configuration
-// The key is expected to be provided via the SUPABASE_KEY environment variable
-// when the script is bundled or served in a Node environment. This value will
-// not be available when running index.html directly in the browser without a
-// build step that injects the key.
-const SUPABASE_URL = 'https://vijkisltymhfwzpcdywr.supabase.co';
-const SUPABASE_KEY = process.env.SUPABASE_KEY;
-const sb = supabase.createClient(SUPABASE_URL, SUPABASE_KEY);
+const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL;
+const SUPABASE_KEY = import.meta.env.VITE_SUPABASE_KEY;
+const sb = createClient(SUPABASE_URL, SUPABASE_KEY);
 
 let annotations = [];
 let displayedAnnotations = [];

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,5 @@
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  base: '/kport-anno/'
+});


### PR DESCRIPTION
## Summary
- configure devcontainer with Node.js 18 and auto npm install
- add Vite project files and Supabase deps
- wire up Supabase client using `import.meta.env`
- deploy built site to `gh-pages` via GitHub Actions
- update README for Codespaces usage

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_6849629e27e4832993ef516334ff7b9f