### PR TITLE
Add session-aware login wrapper

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,8 @@
 <h1>Korean Portrait Annotation Viewer</h1>
 <div id="login-root"></div>
 
+<!-- Wrapped annotation interface for conditional rendering -->
+<div id="annotator-ui" class="hidden">
 <div id="controls">
   <label>Author
     <select id="authorFilter">
@@ -64,6 +66,7 @@
     </form>
   </div>
 </div>
+</div> <!-- end annotator-ui -->
 
 <script type="module" src="./src/main.js"></script>
 <script type="module" src="./src/login.jsx"></script>

--- a/src/AuthWrapper.jsx
+++ b/src/AuthWrapper.jsx
@@ -1,0 +1,33 @@
+import React, { useEffect } from 'react'
+import useAuthStatus from './useAuthStatus.js'
+import GoogleLoginButton from './GoogleLoginButton.jsx'
+
+export default function AuthWrapper({ children }) {
+  const { user, loading } = useAuthStatus()
+
+  useEffect(() => {
+    // Clean up access_token hash that may remain after OAuth redirect
+    if (window.location.hash && window.location.hash.includes('access_token')) {
+      window.location.hash = ''
+    }
+
+    const container = document.getElementById('annotator-ui')
+    if (!loading) {
+      if (user) {
+        container && container.classList.remove('hidden')
+      } else {
+        container && container.classList.add('hidden')
+      }
+    }
+  }, [user, loading])
+
+  if (loading) {
+    return <div>Loading...</div>
+  }
+
+  if (!user) {
+    return <GoogleLoginButton />
+  }
+
+  return <>{children}</>
+}

--- a/src/LogoutButton.jsx
+++ b/src/LogoutButton.jsx
@@ -1,0 +1,19 @@
+import React from 'react'
+import { supabase } from './supabaseClient.js'
+
+export default function LogoutButton() {
+  const handleLogout = async () => {
+    try {
+      await supabase.auth.signOut()
+      console.log('Logged out')
+    } catch (err) {
+      console.error('Logout failed', err)
+    } finally {
+      window.location.href = '/'
+    }
+  }
+
+  return (
+    <button onClick={handleLogout}>Logout</button>
+  )
+}

--- a/src/login.jsx
+++ b/src/login.jsx
@@ -1,9 +1,18 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
-import GoogleLoginButton from './GoogleLoginButton.jsx'
+import AuthWrapper from './AuthWrapper.jsx'
+import LogoutButton from './LogoutButton.jsx'
+
+function LoginRoot() {
+  return (
+    <AuthWrapper>
+      <LogoutButton />
+    </AuthWrapper>
+  )
+}
 
 ReactDOM.createRoot(document.getElementById('login-root')).render(
   <React.StrictMode>
-    <GoogleLoginButton />
+    <LoginRoot />
   </React.StrictMode>
 )

--- a/src/useAuthStatus.js
+++ b/src/useAuthStatus.js
@@ -1,0 +1,34 @@
+import { useState, useEffect } from 'react'
+import { supabase } from './supabaseClient.js'
+
+export default function useAuthStatus() {
+  const [user, setUser] = useState(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    const checkSession = async () => {
+      try {
+        const { data: { session }, error } = await supabase.auth.getSession()
+        if (error) throw error
+        setUser(session?.user ?? null)
+        console.log('Session fetched', session)
+      } catch (err) {
+        console.error('Failed to fetch session', err)
+        setUser(null)
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    checkSession()
+
+    const { data: { subscription } } = supabase.auth.onAuthStateChange((_event, session) => {
+      console.log('Auth state changed', session)
+      setUser(session?.user ?? null)
+    })
+
+    return () => subscription.unsubscribe()
+  }, [])
+
+  return { user, loading }
+}


### PR DESCRIPTION
## Summary
- add `useAuthStatus` hook to monitor Supabase auth session
- add `AuthWrapper` component to toggle UI by login state
- add `LogoutButton` component
- wrap annotation markup in `index.html` for conditional display
- update `login.jsx` to use new wrapper and logout button

## Testing
- `npm run build` *(fails: vite not found)*
- `npm install` *(fails: 403 Forbidden due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_b_6858c93b8ba083299ae61bf76e54f900