### PR TITLE
Fix Supabase client to prevent multiple instances

### DIFF
--- a/src/supabaseClient.js
+++ b/src/supabaseClient.js
@@ -3,4 +3,10 @@ import { createClient } from '@supabase/supabase-js'
 const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL
 const SUPABASE_KEY = import.meta.env.VITE_SUPABASE_KEY
 
-export const supabase = createClient(SUPABASE_URL, SUPABASE_KEY)
+let client = null
+
+if (!client) {
+  client = createClient(SUPABASE_URL, SUPABASE_KEY)
+}
+
+export const supabase = client


### PR DESCRIPTION
## Summary
- make `src/supabaseClient.js` create the Supabase client as a singleton

## Testing
- `npm run build` *(fails: `vite: not found`)*

------
https://chatgpt.com/codex/tasks/task_b_6858ce4c6cb88329b83c4ab20f5fe843