### PR TITLE
Implement singleton pattern for Supabase client

### DIFF
--- a/src/supabaseClient.js
+++ b/src/supabaseClient.js
@@ -3,10 +3,16 @@ import { createClient } from '@supabase/supabase-js'
 const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL
 const SUPABASE_KEY = import.meta.env.VITE_SUPABASE_KEY
 
-let client = null
+// Use a property on globalThis to store the client so that only one
+// instance exists across the entire application lifecycle. This prevents
+// errors such as "Multiple GoTrueClient instances detected" or
+// "AuthSessionMissingError" which can occur when multiple Supabase
+// clients are created.
+let client = globalThis.__supabaseClient__
 
 if (!client) {
   client = createClient(SUPABASE_URL, SUPABASE_KEY)
+  globalThis.__supabaseClient__ = client
 }
 
 export const supabase = client


### PR DESCRIPTION
## Summary
- make Supabase client a singleton using `globalThis`
- add explanatory comments

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_b_6858d025e49c8329978aa84a461e4565